### PR TITLE
Improvements to %-formatting in *printf() functions

### DIFF
--- a/stdio.c
+++ b/stdio.c
@@ -134,6 +134,8 @@ static void oint(FILE *fp, unsigned long n, int base,
 		} else {
 			if (flags & FMT_PLUS)
 				sign = '+';
+			else if (flags & FMT_BLANK)
+				sign = ' ';
 		}
 	}
 	if (bytes == 1)

--- a/stdio.c
+++ b/stdio.c
@@ -157,13 +157,13 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			fill = '0';
 			s++;
 		}
-		while (isdigit(*s)) {
-			wid *= 10;
-			wid += *s++ - '0';
-		}
 		if (*s == '+') {
 			psign = 1;
 			s++;
+		}
+		while (isdigit(*s)) {
+			wid *= 10;
+			wid += *s++ - '0';
 		}
 		while (*s == 'l') {
 			bytes = sizeof(long);

--- a/stdio.c
+++ b/stdio.c
@@ -248,6 +248,9 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 		case 's':
 			ostr(fp, va_arg(ap, char *), wid, flags & FMT_LEFT);
 			break;
+		case 'n':
+			*va_arg(ap, int *) = fp->ostat - beg;
+			break;
 		case '\0':
 			s--;
 			break;

--- a/stdio.c
+++ b/stdio.c
@@ -174,7 +174,7 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			s++;
 		}
 		switch ((c = *s++)) {
-		case 'd':
+		case 'd': case 'i':
 			oint(fp, va_arg(ap, long), 10, 1, wid, fill, psign, bytes, 0);
 			break;
 		case 'u':

--- a/stdio.c
+++ b/stdio.c
@@ -151,9 +151,11 @@ static void oint(FILE *fp, unsigned long n, int base,
 	}
 	s[d] = '\0';
 	fill = (flags & FMT_ZERO) ? '0' : ' ';
+	if (fill == '0' && sign)
+		fputc(sign, fp);
 	for (i = d + !!sign; i < wid; i++)
 		fputc(fill, fp);
-	if (sign)
+	if (fill == ' ' && sign)
 		fputc(sign, fp);
 	ostr(fp, buf, 0);
 }

--- a/stdio.c
+++ b/stdio.c
@@ -117,7 +117,7 @@ static void oint(FILE *fp, unsigned long n, int base, int sign,
 	int d;
 	int i;
 	if (sign && (signed long) n < 0) {
-		neg = 1;
+		psign = neg = 1;
 		n = -n;
 	}
 	if (bytes == 1)
@@ -132,9 +132,9 @@ static void oint(FILE *fp, unsigned long n, int base, int sign,
 		n /= base;
 	}
 	s[d] = '\0';
-	for (i = d + neg; i < wid; i++)
+	for (i = d + psign; i < wid; i++)
 		fputc(fill, fp);
-	if (neg || psign)
+	if (psign)
 		fputc(neg ? '-' : '+', fp);
 	ostr(fp, buf, 0);
 }

--- a/stdio.c
+++ b/stdio.c
@@ -193,6 +193,7 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 		int wid = 0;
 		int bytes = sizeof(int);
 		int flags = 0;
+		int left;
 		char *f;
 		if (c != '%') {
 			fputc(c, fp);
@@ -202,6 +203,7 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			flags |= 1 << (f - fmt_flags);
 			s++;
 		}
+		left = flags & FMT_LEFT;
 		if (*s == '*') {
 			wid = va_arg(ap, int);
 			if (wid < 0) {
@@ -243,10 +245,15 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			oint(fp, va_arg(ap, long), 16, wid, bytes, flags);
 			break;
 		case 'c':
-			fputc(va_arg(ap, int), fp);
+			if (left)
+				fputc(va_arg(ap, int), fp);
+			while (wid-- > 1)
+				fputc(' ', fp);
+			if (!left)
+				fputc(va_arg(ap, int), fp);
 			break;
 		case 's':
-			ostr(fp, va_arg(ap, char *), wid, flags & FMT_LEFT);
+			ostr(fp, va_arg(ap, char *), wid, left);
 			break;
 		case 'n':
 			*va_arg(ap, int *) = fp->ostat - beg;

--- a/stdio.c
+++ b/stdio.c
@@ -180,6 +180,9 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 		case 'u':
 			oint(fp, va_arg(ap, long), 10, 0, wid, fill, 0, bytes, 0);
 			break;
+		case 'o':
+			oint(fp, va_arg(ap, long), 8, 0, wid, fill, 0, bytes, 0);
+			break;
 		case 'x':
 		case 'p':
 			oint(fp, va_arg(ap, long), 16, 0, wid, fill, 0, bytes, 0);

--- a/stdio.c
+++ b/stdio.c
@@ -202,9 +202,18 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			flags |= 1 << (f - fmt_flags);
 			s++;
 		}
-		while (isdigit(*s)) {
-			wid *= 10;
-			wid += *s++ - '0';
+		if (*s == '*') {
+			wid = va_arg(ap, int);
+			if (wid < 0) {
+				flags |= FMT_LEFT;
+				wid = -wid;
+			}
+			s++;
+		} else {
+			while (isdigit(*s)) {
+				wid *= 10;
+				wid += *s++ - '0';
+			}
 		}
 		while (*s == 'l') {
 			bytes = sizeof(long);

--- a/stdio.c
+++ b/stdio.c
@@ -237,8 +237,9 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 		case 'o':
 			oint(fp, va_arg(ap, long), 8, wid, bytes, flags);
 			break;
-		case 'x':
 		case 'p':
+			flags |= FMT_ALT;
+		case 'x':
 			oint(fp, va_arg(ap, long), 16, wid, bytes, flags);
 			break;
 		case 'X':

--- a/stdio.c
+++ b/stdio.c
@@ -88,13 +88,17 @@ int putchar(int c)
 	return fputc(c, stdout);
 }
 
-static void ostr(FILE *fp, char *s, int wid)
+static void ostr(FILE *fp, char *s, int wid, int left)
 {
 	int fill = wid - strlen(s);
-	while (fill-- > 0)
-		fputc(' ', fp);
+	if (!left)
+		while (fill-- > 0)
+			fputc(' ', fp);
 	while (*s)
 		fputc((unsigned char) *s++, fp);
+	if (left)
+		while (fill-- > 0)
+			fputc(' ', fp);
 }
 
 static int digits(unsigned long n, int base)
@@ -172,7 +176,7 @@ static void oint(FILE *fp, unsigned long n, int base,
 	if (fill == '0' && !left)
 		while (i++ < wid)
 			fputc('0', fp);
-	ostr(fp, buf, 0);
+	ostr(fp, buf, 0, 0);
 	if (left)
 		while (i++ < wid)
 			fputc(' ', fp);
@@ -233,7 +237,7 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			fputc(va_arg(ap, int), fp);
 			break;
 		case 's':
-			ostr(fp, va_arg(ap, char *), wid);
+			ostr(fp, va_arg(ap, char *), wid, flags & FMT_LEFT);
 			break;
 		case '\0':
 			s--;

--- a/stdio.c
+++ b/stdio.c
@@ -231,6 +231,7 @@ int vfprintf(FILE *fp, char *fmt, va_list ap)
 			oint(fp, va_arg(ap, long), 10, wid, bytes, flags);
 			break;
 		case 'u':
+			flags &= ~FMT_ALT;
 			oint(fp, va_arg(ap, long), 10, wid, bytes, flags);
 			break;
 		case 'o':

--- a/stdio.c
+++ b/stdio.c
@@ -124,6 +124,7 @@ static void oint(FILE *fp, unsigned long n, int base,
 	int neg = 0;
 	int sign = '\0';
 	char fill;
+	int ucase;
 	int d;
 	int i;
 	if (flags & FMT_SIGNED) {
@@ -145,8 +146,9 @@ static void oint(FILE *fp, unsigned long n, int base,
 	if (bytes == 4)
 		n &= 0xffffffff;
 	d = digits(n, base);
+	ucase = flags & FMT_UCASE;
 	for (i = 0; i < d; i++) {
-		s[d - i - 1] = (flags & FMT_UCASE) ? digs_uc[n % base] : digs[n % base];
+		s[d - i - 1] = ucase ? digs_uc[n % base] : digs[n % base];
 		n /= base;
 	}
 	s[d] = '\0';


### PR DESCRIPTION
With this set of changes, printf() and related functions are closer to C89-compliance, although there are still some missing features.

Features added:
  * %i: alias for %d
  * %o: octal
  * %n: save current output length
  * getting width from argument (e.g. printf("%*d", width, n);)
  * left justification (e.g. "%-10s")
  * blank positive sign (e.g. "% d")
  * alternate form (e.g. "%#x")

Features still missing:
  * length modifiers for integer conversions (e.g. "%hd") were not thoroughly tested
  * length modifiers for %n (i.e. "%hn" and "%ln")
  * precision (e.g. "%.5s")
  * all float-related conversions (%e, %E, %f, %g and %G)

Since there are so many valid combinations of formatting features, I've used [a script to run random tests](https://gist.github.com/lecram/71cf186d02dcde7a49e2809879a2ef4a), comparing the output of neatcc+neatlibc with the one from TCC+musl. That script also includes a small set of hand-written "smoke tests" / "sanity checks".