### PR TITLE
convert x64 assembler files to nasm syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OUT = x64
 
 # default assemblers
 ASx64 = nasm -f elf64
-ASx86 = fasm
+ASx86 = nasm -f elf
 ASarm = neatas
 
 CC = ncc

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 OUT = x64
 
 # default assemblers
-ASx64 = fasm
+ASx64 = nasm -f elf64
 ASx86 = fasm
 ASarm = neatas
 

--- a/x64/bits.s
+++ b/x64/bits.s
@@ -1,7 +1,8 @@
-format ELF64
 
-public htonl
-public ntohl
+
+
+global htonl
+global ntohl
 htonl:
 ntohl:
 	mov	eax, edi
@@ -10,8 +11,8 @@ ntohl:
 	xchg	al, ah
 	ret
 
-public htons
-public ntohs
+global htons
+global ntohs
 htons:
 ntohs:
 	mov	eax, edi

--- a/x64/lmem.s
+++ b/x64/lmem.s
@@ -1,6 +1,7 @@
-format ELF64
 
-public __memcpylong
+
+
+global __memcpylong
 __memcpylong:
 	mov	rax, rdi
 	mov	rcx, rdx
@@ -9,7 +10,7 @@ __memcpylong:
 	rep movsq
 	ret
 
-public __memsetlong
+global __memsetlong
 __memsetlong:
 	mov	rcx, rdx
 	mov	rax, rsi

--- a/x64/memtst.s
+++ b/x64/memtst.s
@@ -1,6 +1,7 @@
-format ELF64
 
-public memtst_back
+
+
+global memtst_back
 memtst_back:
 	mov	rax, rbp
 bt_up:	cmp	rdi, 0

--- a/x64/setjmp.s
+++ b/x64/setjmp.s
@@ -1,6 +1,7 @@
-format ELF64
 
-public setjmp
+
+
+global setjmp
 setjmp:
 	mov	[rdi + 0 * 8], rbx
 	mov	[rdi + 1 * 8], rbp
@@ -15,7 +16,7 @@ setjmp:
 	xor	rax, rax
 	ret
 
-public longjmp
+global longjmp
 longjmp:
 	mov	rbx, [rdi + 0 * 8]
 	mov	rbp, [rdi + 1 * 8]

--- a/x64/start.s
+++ b/x64/start.s
@@ -1,10 +1,11 @@
-format ELF64
 
-extrn environ
 
-extrn main
-extrn __neatlibc_exit
-public _start
+
+extern environ
+
+extern main
+extern __neatlibc_exit
+global _start
 _start:
 	xor	rbp, rbp
 	pop	rdi			; argc

--- a/x64/string.s
+++ b/x64/string.s
@@ -1,6 +1,7 @@
-format ELF64
 
-public memcpy
+
+
+global memcpy
 memcpy:
 	mov	rax, rdi
 	mov	rcx, rdx
@@ -8,7 +9,7 @@ memcpy:
 	rep movsb
 	ret
 
-public memmove
+global memmove
 memmove:
 	mov	rcx, rdx
 	cmp	rdi, rsi
@@ -32,7 +33,7 @@ memmove:
 	rep movsb
 	ret
 
-public memset
+global memset
 memset:
 	mov	rcx, rdx
 	mov	rax, rsi
@@ -42,7 +43,7 @@ memset:
 	mov	rax, rdx
 	ret
 
-public memchr
+global memchr
 memchr:
 	mov	rax, rsi
 	mov	rcx, rdx
@@ -58,7 +59,7 @@ memchr:
 	xor	eax, eax
 	ret
 
-public memcmp
+global memcmp
 memcmp:
 	xor	eax, eax
 	mov	rcx, rdx
@@ -75,7 +76,7 @@ memcmp:
 .ret:
 	ret
 
-public strlen
+global strlen
 strlen:
 	xor	eax, eax
 	mov	rcx, -1
@@ -86,7 +87,7 @@ strlen:
 	dec	rax
 	ret
 
-public memrchr
+global memrchr
 memrchr:
 	mov	eax, esi
 	mov	rcx, rdx
@@ -104,7 +105,7 @@ memrchr:
 	xor	eax, eax
 	ret
 
-public strchr
+global strchr
 strchr:
 .loop:
 	mov	al, [rdi]
@@ -118,7 +119,7 @@ strchr:
 	mov	rax, rdi
 	ret
 
-public strcmp
+global strcmp
 strcmp:
 	xor	eax, eax
 .loop:
@@ -135,7 +136,7 @@ strcmp:
 	sub	rax, rcx
 	ret
 
-public strcpy
+global strcpy
 strcpy:
 	mov	rdx, rdi
 	cld
@@ -147,7 +148,7 @@ strcpy:
 	mov	rax, rdx
 	ret
 
-public strrchr
+global strrchr
 strrchr:
 	xor	edx, edx
 	dec	rdi
@@ -164,7 +165,7 @@ strrchr:
 	mov	rax, rdx
 	ret
 
-public strncmp
+global strncmp
 strncmp:
 	xor	eax, eax
 .loop:

--- a/x64/syscall.s
+++ b/x64/syscall.s
@@ -1,4 +1,6 @@
-format ELF64
+
+global errno
+errno	dq	0
 
 __syscall:
 	mov	r10, rcx
@@ -14,307 +16,306 @@ __syscall:
 done:
 	ret
 
-errno	dq	0
-public errno
-
-public _exit
+global _exit
 _exit:
 	mov	rax, 60
 	jmp	__syscall
 
-public fork
+global fork
 fork:
 	mov	eax, 57
 	jmp	__syscall
 
-public read
+global read
 read:
 	mov	eax, 0
 	jmp	__syscall
 
-public write
+global write
 write:
 	mov	eax, 1
 	jmp	__syscall
 
-public open
+global open
 open:
 	mov	eax, 2
 	jmp	__syscall
 
-public close
+global close
 close:
 	mov	eax, 3
 	jmp	__syscall
 
-public waitpid
+global waitpid
 waitpid:
 	xor	rcx, rcx
 	mov	eax, 61
 	jmp	__syscall
 
-public creat
+global creat
 creat:
 	mov	eax, 85
 	jmp	__syscall
 
-public link
+global link
 link:
 	mov	eax, 86
 	jmp	__syscall
 
-public unlink
+global unlink
 unlink:
 	mov	eax, 87
 	jmp	__syscall
 
-public execve
+global execve
 execve:
 	mov	eax, 59
 	jmp	__syscall
 
-public chdir
+global chdir
 chdir:
 	mov	eax, 80
 	jmp	__syscall
 
-public time
+global time
 time:
 	mov	eax, 201
 	jmp	__syscall
 
-public mknod
+global mknod
 mknod:
 	mov	eax, 133
 	jmp	__syscall
 
-public chmod
+global chmod
 chmod:
 	mov	eax, 90
 	jmp	__syscall
 
-public lseek
+global lseek
 lseek:
 	mov	eax, 8
 	jmp	__syscall
 
-public getpid
+global getpid
 getpid:
 	mov	eax, 39
 	jmp	__syscall
 
-public mount
+global mount
 mount:
 	mov	eax, 165
 	jmp	__syscall
 
-public umount
+global umount
 umount:
 	xor	rsi, rsi
 	mov	eax, 166
 	jmp	__syscall
 
-public setuid
+global setuid
 setuid:
 	mov	eax, 105
 	jmp	__syscall
 
-public getuid
+global getuid
 getuid:
 	mov	eax, 104
 	jmp	__syscall
 
-public utime
+global utime
 utime:
 	mov	eax, 132
 	jmp	__syscall
 
-public access
+global access
 access:
 	mov	eax, 21
 	jmp	__syscall
 
-public sync
+global sync
 sync:
 	mov	eax, 162
 	jmp	__syscall
 
-public kill
+global kill
 kill:
 	mov	eax, 62
 	jmp	__syscall
 
-public mkdir
+global mkdir
 mkdir:
 	mov	eax, 83
 	jmp	__syscall
 
-public rmdir
+global rmdir
 rmdir:
 	mov	eax, 83
 	jmp	__syscall
 
-public __dup as 'dup'
+global __dup
+global dup
 __dup:
+dup:
 	mov	eax, 32
 	jmp	__syscall
 
-public pipe
+global pipe
 pipe:
 	mov	eax, 22
 	jmp	__syscall
 
-public brk
+global brk
 brk:
 	mov	eax, 12
 	jmp	__syscall
 
-public setgid
+global setgid
 setgid:
 	mov	eax, 106
 	jmp	__syscall
 
-public getgid
+global getgid
 getgid:
 	mov	eax, 104
 	jmp	__syscall
 
-public geteuid
+global geteuid
 geteuid:
 	mov	eax, 107
 	jmp	__syscall
 
-public getegid
+global getegid
 getegid:
 	mov	eax, 108
 	jmp	__syscall
 
-public ioctl
+global ioctl
 ioctl:
 	mov	eax, 16
 	jmp	__syscall
 
-public fcntl
+global fcntl
 fcntl:
 	mov	eax, 72
 	jmp	__syscall
 
-public dup2
+global dup2
 dup2:
 	mov	eax, 33
 	jmp	__syscall
 
-public getppid
+global getppid
 getppid:
 	mov	eax, 110
 	jmp	__syscall
 
-public setsid
+global setsid
 setsid:
 	mov	eax, 112
 	jmp	__syscall
 
-public gettimeofday
+global gettimeofday
 gettimeofday:
 	mov	eax, 96
 	jmp	__syscall
 
-public settimeofday
+global settimeofday
 settimeofday:
 	mov	eax, 164
 	jmp	__syscall
 
-public mmap
+global mmap
 mmap:
 	mov	eax, 9
 	jmp	__syscall
 
-public munmap
+global munmap
 munmap:
 	mov	eax, 11
 	jmp	__syscall
 
-public stat
+global stat
 stat:
 	mov	eax, 4
 	jmp	__syscall
 
-public lstat
+global lstat
 lstat:
 	mov	eax, 6
 	jmp	__syscall
 
-public fstat
+global fstat
 fstat:
 	mov	eax, 5
 	jmp	__syscall
 
-public clone
+global clone
 clone:
 	mov	eax, 56
 	jmp	__syscall
 
-public uname
+global uname
 uname:
 	mov	eax, 63
 	jmp	__syscall
 
-public fchdir
+global fchdir
 fchdir:
 	mov	eax, 81
 	jmp	__syscall
 
-public getdents
+global getdents
 getdents:
 	mov	eax, 78
 	jmp	__syscall
 
-public nanosleep
+global nanosleep
 nanosleep:
 	mov	eax, 35
 	jmp	__syscall
 
-public poll
+global poll
 poll:
 	mov	eax, 7
 	jmp	__syscall
 
-public chown
+global chown
 chown:
 	mov	eax, 92
 	jmp	__syscall
 
-public getcwd
+global getcwd
 getcwd:
 	mov	eax, 79
 	jmp	__syscall
 
-public sigaction
+global sigaction
 sigaction:
 	mov	eax, 13
 	jmp	__syscall
 
-public sigreturn
+global sigreturn
 sigreturn:
 	mov	eax, 15
 	jmp	__syscall
 
-public fsync
+global fsync
 fsync:
 	mov	eax, 74
 	jmp	__syscall
 
-public fdatasync
+global fdatasync
 fdatasync:
 	mov	eax, 75
 	jmp	__syscall
 
-public truncate
+global truncate
 truncate:
 	mov	eax, 76
 	jmp	__syscall
 
-public ftruncate
+global ftruncate
 ftruncate:
 	mov	eax, 77
 	jmp	__syscall

--- a/x86/bits.s
+++ b/x86/bits.s
@@ -1,7 +1,8 @@
-format ELF
 
-public htonl
-public ntohl
+
+
+global htonl
+global ntohl
 htonl:
 ntohl:
 	mov	eax, [esp+4]
@@ -10,8 +11,8 @@ ntohl:
 	xchg	al, ah
 	ret
 
-public htons
-public ntohs
+global htons
+global ntohs
 htons:
 ntohs:
 	mov	eax, [esp+4]

--- a/x86/lmem.s
+++ b/x86/lmem.s
@@ -1,6 +1,7 @@
-format ELF
 
-public __memcpylong
+
+
+global __memcpylong
 __memcpylong:
 	push	esi
 	push	edi
@@ -15,7 +16,7 @@ __memcpylong:
 	pop	esi
 	ret
 
-public __memsetlong
+global __memsetlong
 __memsetlong:
 	push	edi
 	mov	edi, [esp+8]

--- a/x86/memtst.s
+++ b/x86/memtst.s
@@ -1,6 +1,7 @@
-format ELF
 
-public memtst_back
+
+
+global memtst_back
 memtst_back:
 	mov	eax, ebp
 	mov	ecx, [esp+4]

--- a/x86/setjmp.s
+++ b/x86/setjmp.s
@@ -1,6 +1,7 @@
-format ELF
 
-public setjmp
+
+
+global setjmp
 setjmp:
 	mov	eax, [esp + 4]
 	mov	[eax + 0 * 4], ebx
@@ -14,7 +15,7 @@ setjmp:
 	xor	eax, eax
 	ret
 
-public longjmp
+global longjmp
 longjmp:
 	mov	edx, [esp + 4]
 	mov	eax, [esp + 8]

--- a/x86/start.s
+++ b/x86/start.s
@@ -1,10 +1,11 @@
-format ELF
 
-extrn environ
 
-extrn main
-extrn __neatlibc_exit
-public _start
+
+extern environ
+
+extern main
+extern __neatlibc_exit
+global _start
 _start:
 	xor	ebp, ebp
 	pop	ecx

--- a/x86/string.s
+++ b/x86/string.s
@@ -1,6 +1,7 @@
-format ELF
 
-public memcpy
+
+
+global memcpy
 memcpy:
 	push	esi
 	push	edi
@@ -14,7 +15,7 @@ memcpy:
 	pop	esi
 	ret
 
-public memmove
+global memmove
 memmove:
 	push	esi
 	push	edi
@@ -45,7 +46,7 @@ memmove:
 	pop	esi
 	ret
 
-public memset
+global memset
 memset:
 	push	edi
 	mov	edi, [esp+8]
@@ -58,7 +59,7 @@ memset:
 	mov	eax, edx
 	ret
 
-public memchr
+global memchr
 memchr:
 	mov	eax, [esp+8]
 	mov	ecx, [esp+12]
@@ -78,7 +79,7 @@ memchr:
 	pop	edi
 	ret
 
-public memcmp
+global memcmp
 memcmp:
 	push	esi
 	push	edi
@@ -98,7 +99,7 @@ memcmp:
 	pop 	esi
 	ret
 
-public strlen
+global strlen
 strlen:
 	push	edi
 	mov	edi, [esp+8]
@@ -112,7 +113,7 @@ strlen:
 	pop	edi
 	ret
 
-public memrchr
+global memrchr
 memrchr:
 	mov	eax, [esp+8]
 	mov	ecx, [esp+12]
@@ -134,7 +135,7 @@ memrchr:
 	pop	edi
 	ret
 
-public strchr
+global strchr
 strchr:
 	mov	ecx, [esp+4]
 	mov	edx, [esp+8]
@@ -150,7 +151,7 @@ strchr:
 	mov	eax, ecx
 	ret
 
-public strcmp
+global strcmp
 strcmp:
 	mov	ecx, [esp+4]
 	mov	edx, [esp+8]
@@ -169,7 +170,7 @@ strcmp:
 	sub	eax, ecx
 	ret
 
-public strcpy
+global strcpy
 strcpy:
 	push	edi
 	push	esi
@@ -187,7 +188,7 @@ strcpy:
 	mov	eax, edx
 	ret
 
-public strrchr
+global strrchr
 strrchr:
 	push	edi
 	mov	edi, [esp+8]
@@ -208,7 +209,7 @@ strrchr:
 	pop	edi
 	ret
 
-public strncmp
+global strncmp
 strncmp:
 	mov	ecx, [esp+4]
 	mov	edx, [esp+8]

--- a/x86/syscall.s
+++ b/x86/syscall.s
@@ -1,4 +1,6 @@
-format ELF
+
+global errno
+errno	dd	0
 
 __syscall:
 	push	ebp
@@ -29,310 +31,309 @@ done:
 	pop	ebp
 	ret
 
-errno	dd	0
-public errno
-
-public _exit
+global _exit
 _exit:
 	mov	eax, 1
 	jmp	__syscall
 
-public fork
+global fork
 fork:
 	mov	eax, 2
 	jmp	__syscall
 
-public read
+global read
 read:
 	mov	eax, 3
 	jmp	__syscall
 
-public write
+global write
 write:
 	mov	eax, 4
 	jmp	__syscall
 
-public open
+global open
 open:
 	mov	eax, 5
 	jmp	__syscall
 
-public close
+global close
 close:
 	mov	eax, 6
 	jmp	__syscall
 
-public waitpid
+global waitpid
 waitpid:
 	mov	eax, 7
 	jmp	__syscall
 
-public creat
+global creat
 creat:
 	mov	eax, 8
 	jmp	__syscall
 
-public link
+global link
 link:
 	mov	eax, 9
 	jmp	__syscall
 
-public unlink
+global unlink
 unlink:
 	mov	eax, 10
 	jmp	__syscall
 
-public execve
+global execve
 execve:
 	mov	eax, 11
 	jmp	__syscall
 
-public chdir
+global chdir
 chdir:
 	mov	eax, 12
 	jmp	__syscall
 
-public time
+global time
 time:
 	mov	eax, 13
 	jmp	__syscall
 
-public mknod
+global mknod
 mknod:
 	mov	eax, 14
 	jmp	__syscall
 
-public chmod
+global chmod
 chmod:
 	mov	eax, 15
 	jmp	__syscall
 
-public lseek
+global lseek
 lseek:
 	mov	eax, 19
 	jmp	__syscall
 
-public getpid
+global getpid
 getpid:
 	mov	eax, 20
 	jmp	__syscall
 
-public mount
+global mount
 mount:
 	mov	eax, 21
 	jmp	__syscall
 
-public umount
+global umount
 umount:
 	mov	eax, 22
 	jmp	__syscall
 
-public setuid
+global setuid
 setuid:
 	mov	eax, 23
 	jmp	__syscall
 
-public getuid
+global getuid
 getuid:
 	mov	eax, 24
 	jmp	__syscall
 
-public utime
+global utime
 utime:
 	mov	eax, 30
 	jmp	__syscall
 
-public access
+global access
 access:
 	mov	eax, 33
 	jmp	__syscall
 
-public sync
+global sync
 sync:
 	mov	eax, 36
 	jmp	__syscall
 
-public kill
+global kill
 kill:
 	mov	eax, 37
 	jmp	__syscall
 
-public mkdir
+global mkdir
 mkdir:
 	mov	eax, 39
 	jmp	__syscall
 
-public rmdir
+global rmdir
 rmdir:
 	mov	eax, 40
 	jmp	__syscall
 
-public __dup as 'dup'
+global __dup
+global dup
+dup:
 __dup:
 	mov	eax, 41
 	jmp	__syscall
 
-public pipe
+global pipe
 pipe:
 	mov	eax, 42
 	jmp	__syscall
 
-public brk
+global brk
 brk:
 	mov	eax, 45
 	jmp	__syscall
 
-public setgid
+global setgid
 setgid:
 	mov	eax, 46
 	jmp	__syscall
 
-public getgid
+global getgid
 getgid:
 	mov	eax, 47
 	jmp	__syscall
 
-public signal
+global signal
 signal:
 	mov	eax, 48
 	jmp	__syscall
 
-public geteuid
+global geteuid
 geteuid:
 	mov	eax, 49
 	jmp	__syscall
 
-public getegid
+global getegid
 getegid:
 	mov	eax, 50
 	jmp	__syscall
 
-public ioctl
+global ioctl
 ioctl:
 	mov	eax, 54
 	jmp	__syscall
 
-public fcntl
+global fcntl
 fcntl:
 	mov	eax, 55
 	jmp	__syscall
 
-public dup2
+global dup2
 dup2:
 	mov	eax, 63
 	jmp	__syscall
 
-public getppid
+global getppid
 getppid:
 	mov	eax, 64
 	jmp	__syscall
 
-public setsid
+global setsid
 setsid:
 	mov	eax, 66
 	jmp	__syscall
 
-public gettimeofday
+global gettimeofday
 gettimeofday:
 	mov	eax, 78
 	jmp	__syscall
 
-public settimeofday
+global settimeofday
 settimeofday:
 	mov	eax, 79
 	jmp	__syscall
 
-public mmap
+global mmap
 mmap:
 	mov	eax, 192
 	jmp	__syscall
 
-public munmap
+global munmap
 munmap:
 	mov	eax, 91
 	jmp	__syscall
 
-public stat
+global stat
 stat:
 	mov	eax, 106
 	jmp	__syscall
 
-public lstat
+global lstat
 lstat:
 	mov	eax, 107
 	jmp	__syscall
 
-public fstat
+global fstat
 fstat:
 	mov	eax, 108
 	jmp	__syscall
 
-public clone
+global clone
 clone:
 	mov	eax, 120
 	jmp	__syscall
 
-public uname
+global uname
 uname:
 	mov	eax, 122
 	jmp	__syscall
 
-public fchdir
+global fchdir
 fchdir:
 	mov	eax, 133
 	jmp	__syscall
 
-public getdents
+global getdents
 getdents:
 	mov	eax, 141
 	jmp	__syscall
 
-public nanosleep
+global nanosleep
 nanosleep:
 	mov	eax, 162
 	jmp	__syscall
 
-public poll
+global poll
 poll:
 	mov	eax, 168
 	jmp	__syscall
 
-public chown
+global chown
 chown:
 	mov	eax, 182
 	jmp	__syscall
 
-public getcwd
+global getcwd
 getcwd:
 	mov	eax, 183
 	jmp	__syscall
 
-public sigaction
+global sigaction
 sigaction:
 	mov	eax, 67
 	jmp	__syscall
 
-public sigreturn
+global sigreturn
 sigreturn:
 	mov	eax, 119
 	jmp	__syscall
 
-public fsync
+global fsync
 fsync:
 	mov	eax, 118
 	jmp	__syscall
 
-public fdatasync
+global fdatasync
 fdatasync:
 	mov	eax, 148
 	jmp	__syscall
 
-public truncate
+global truncate
 truncate:
 	mov	eax, 92
 	jmp	__syscall
 
-public ftruncate
+global ftruncate
 ftruncate:
 	mov	eax, 93
 	jmp	__syscall


### PR DESCRIPTION
files were programmatically converted using [0], with minimal manual
corrections in syscall.s.

sabotage linux[1] has a strict "no binaries" policy, so it is not possible
to bootstrap fasm, which is written in fasm, from source.

nasm otoh is written in C, and readily available as it is required as a
prerequisite for other packages.
additionally its syntax is almost identical.

[0]: http://bogdro.evai.pl/inne/fasm2nasm.txt
[1]: https://github.com/sabotage-linux/sabotage